### PR TITLE
Stop suppressing tab animations

### DIFF
--- a/src/Views/Encoding/Braille.tsx
+++ b/src/Views/Encoding/Braille.tsx
@@ -12,7 +12,6 @@ class Braille extends TabViewBase {
         <div className="Braille-content">
           <Tabs
             activeKey={this.state.activeKey}
-            animation={false}
             id="Braille-tabs"
             // tslint:disable-next-line: no-any
             onSelect={(activeKey: any) => this.onTabSelect(activeKey as number)}

--- a/src/Views/Encoding/Morse.tsx
+++ b/src/Views/Encoding/Morse.tsx
@@ -12,7 +12,6 @@ class Morse extends TabViewBase {
       <div className="Morse">
         <Tabs
           activeKey={this.state.activeKey}
-          animation={false}
           id="Morse-tabs"
           // tslint:disable-next-line: no-any
           onSelect={(activeKey: any) => this.onTabSelect(activeKey as number)}

--- a/src/Views/Encoding/Semaphore.tsx
+++ b/src/Views/Encoding/Semaphore.tsx
@@ -12,7 +12,6 @@ class Semaphore extends TabViewBase {
         <div className="Semaphore-content">
           <Tabs
             activeKey={this.state.activeKey}
-            animation={false}
             id="Semaphore-tabs"
             // tslint:disable-next-line: no-any
             onSelect={(activeKey: any) => this.onTabSelect(activeKey as number)}

--- a/src/Views/Reference/CharacterEncodings.tsx
+++ b/src/Views/Reference/CharacterEncodings.tsx
@@ -31,7 +31,6 @@ class CharacterEncodings extends LocalStorageComponent<Props, State, SavedState>
         <div className="CharacterEncodings-content">
           <Tabs
             activeKey={this.state.activeKey}
-            animation={false}
             id="CharacterEncodings-tabs"
             // tslint:disable-next-line: no-any
             onSelect={(activeKey: any) => this.onTabSelect(activeKey as number)}

--- a/src/Views/Reference/Resistors.tsx
+++ b/src/Views/Reference/Resistors.tsx
@@ -12,7 +12,6 @@ class Resistors extends TabViewBase {
         <div className="Resistors-content">
           <Tabs
             activeKey={this.state.activeKey}
-            animation={false}
             id="Resistors-tabs"
             // tslint:disable-next-line: no-any
             onSelect={(activeKey: any) => this.onTabSelect(activeKey as number)}


### PR DESCRIPTION
During the transition to Bootstrap 4 the animation suppression property
was renamed. Since the transitions seem fine it's best to stop
suppressing them.