### PR TITLE
LocalStorage refactor

### DIFF
--- a/src/Data/LocalStorageComponent.ts
+++ b/src/Data/LocalStorageComponent.ts
@@ -1,24 +1,7 @@
-import compareVersions from 'compare-versions';
 import { Component } from 'react';
 import LocalStorage from './LocalStorage';
-import { version } from '../version';
 
 abstract class LocalStorageComponent<P = {}, S = {}, SavedState = {}> extends Component<P, S> {
-  private readonly VERSION_STORAGE_KEY: string = 'puzztoolVersion';
-
-  public constructor(props: P) {
-    super(props);
-
-    // If the current localstorage was created with a prior version of puzztool, clear
-    // the local storage to get rid of any obsolete or incompatible artifacts
-    const previousVersion = LocalStorage.getObject<string>(this.VERSION_STORAGE_KEY);
-    if (this.versionIncreased(previousVersion, version)) {
-      LocalStorage.clear();
-      // Store the current version
-      LocalStorage.setObject<string>(this.VERSION_STORAGE_KEY, version);
-    }
-  }
-
   public componentDidMount() {
     this.restoreState();
     this.updateState();
@@ -33,17 +16,6 @@ abstract class LocalStorageComponent<P = {}, S = {}, SavedState = {}> extends Co
   protected abstract onSaveState(): SavedState;
   protected abstract onRestoreState(savedState: SavedState | null): void;
   protected abstract onUpdateState(): void;
-
-  private versionIncreased(prev: string | null, current: string): boolean {
-    if (prev == null) {
-      // If there's no recorded version number, this is the user's first visit
-      // to the page since 0.7.0 released.  To clean up any potential legacy
-      // incompatabilities, clear storage and write the version.
-      return true;
-    }
-
-    return compareVersions(current, prev) === 1;
-  }
 
   private saveState() {
     LocalStorage.setObject<SavedState>(this.getLocalStorageKey(), this.onSaveState());

--- a/src/Data/LocalStorageHooks.ts
+++ b/src/Data/LocalStorageHooks.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import LocalStorage from './LocalStorage';
+
+export function useLocalStorage<T>(
+  localStorageKey: string,
+  onRestoreState: (state: T | null) => void,
+  onSaveState: () => T) {
+  // This effect only runs on the first mount of the control or whenever the
+  // `localStorageKey` value changes. `onRestoreState` is intentionally omitted
+  // since each call will have a unique version of the function.
+  useEffect(
+    () => onRestoreState(LocalStorage.getObject<T>(localStorageKey)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [localStorageKey]);
+
+  // This effect runs on every update of the control because the deps parameter
+  // is intentionally omitted.
+  useEffect(() => LocalStorage.setObject(localStorageKey, onSaveState()));
+}

--- a/src/Data/LocalStorageHooks.ts
+++ b/src/Data/LocalStorageHooks.ts
@@ -1,14 +1,16 @@
-import { useEffect } from 'react';
+import { useEffect, useLayoutEffect } from 'react';
 import LocalStorage from './LocalStorage';
 
 export function useLocalStorage<T>(
   localStorageKey: string,
   onRestoreState: (state: T | null) => void,
   onSaveState: () => T) {
-  // This effect only runs on the first mount of the control or whenever the
-  // `localStorageKey` value changes. `onRestoreState` is intentionally omitted
-  // since each call will have a unique version of the function.
-  useEffect(
+  // This effect runs synchronously on the first mount of the control or
+  // whenever the `localStorageKey` value changes. This is to ensure that there
+  // is no flickering as the data is rendered. `onRestoreState` is intentionally
+  // omitted from deps since each call will have a unique version of the
+  // function.
+  useLayoutEffect(
     () => onRestoreState(LocalStorage.getObject<T>(localStorageKey)),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [localStorageKey]);

--- a/src/Resistor/ResistorInput.tsx
+++ b/src/Resistor/ResistorInput.tsx
@@ -3,9 +3,14 @@ import { ResistorColorEntry as Color, Resistor } from 'puzzle-lib';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import ButtonToolbar from 'react-bootstrap/ButtonToolbar';
 import Card from 'react-bootstrap/Card';
+import { useLocalStorage } from '../Data/LocalStorageHooks';
 import ResistorColorSelector from './ResistorColorSelector';
 import ResistorPicture from './ResistorPicture';
 import './ResistorInput.scss';
+
+interface SavedState {
+  bands: (Color | null)[];
+}
 
 function getResistorValue(bands: (Color | null)[]) {
   // The last band is a tolerance so we need to calculate the value without it.
@@ -26,11 +31,26 @@ function ResistorInput() {
   const [value, setValue] = useState(getResistorValue(initialBands));
   const [bands, setBands] = useState(initialBands);
 
+  useLocalStorage<SavedState>(
+    'ResistorInput',
+    (savedState) => {
+      if (savedState) {
+        updateBands(savedState.bands);
+      }
+    },
+    () => {
+      return { bands };
+    });
+
+  function updateBands(newBands: (Color | null)[]) {
+    setBands(newBands);
+    setValue(getResistorValue(newBands));
+  }
+
   function onColorChange(index: number, color?: Color) {
     const newBands = Array.from(bands);
     newBands[index] = color || null;
-    setValue(getResistorValue(newBands));
-    setBands(newBands);
+    updateBands(newBands);
   }
 
   const colorsWithValue = Resistor.colorTable.filter(color => color.hasValue());


### PR DESCRIPTION
* Moved version check logic to the LocalStorage class and updated it to
  compare for equality rather than looking for newer version numbers.
* Added the version check to the `isSupported()` function so it's done
  automatically once per app launch.
* Created the hook `useLocalStorage` for use in function components and
  added support to the `ResistorInput` component.