### PR TITLE
Update pigpen image to consistent font and spacing

### DIFF
--- a/src/Images/pigpen_key.svg
+++ b/src/Images/pigpen_key.svg
@@ -7,6 +7,11 @@
    version="1.0"
    viewBox = "0 0 230 230"
    id="svg2">
+   <defs>
+      <style>
+         @import url("https://fonts.googleapis.com/css?family=Roboto:400,400i,700,700i");
+      </style>
+   </defs>
   <g
      transform="translate(-9.5,-9.5)"
      id="l1">
@@ -84,108 +89,108 @@
        transform="translate(36.321,149.5)"
        xlink:href="#p6" />
     <text
-       x="26.760742"
-       y="41.790039"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">A</text>
+       x="27"
+       y="42"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">A</text>
     <text
-       x="56.663086"
-       y="41.790039"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">B</text>
+       x="58"
+       y="42"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">B</text>
     <text
-       x="87.302734"
-       y="41.780273"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">C</text>
+       x="87"
+       y="42"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">C</text>
     <text
-       x="25.803711"
-       y="71.790039"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">D</text>
+       x="28"
+       y="72"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">D</text>
     <text
-       x="57.483398"
-       y="71.790039"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">E</text>
+       x="58"
+       y="72"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">E</text>
     <text
-       x="87.59082"
-       y="71.790039"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">F</text>
+       x="88"
+       y="72"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">F</text>
     <text
-       x="26.53125"
-       y="101.78027"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">G</text>
+       x="27"
+       y="102"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">G</text>
     <text
-       x="56.130859"
-       y="101.79004"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">H</text>
+       x="57"
+       y="102"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">H</text>
     <text
-       x="90.78418"
-       y="101.79004"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">I</text>
+       x="91"
+       y="102"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">I</text>
     <text
-       x="149.76367"
-       y="37.288086"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">J</text>
+       x="147"
+       y="39"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">J</text>
     <text
-       x="175.53027"
-       y="39.290039"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">K</text>
+       x="177"
+       y="39"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">K</text>
     <text
-       x="209.9834"
-       y="39.290039"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">L</text>
+       x="210"
+       y="39"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">L</text>
     <text
-       x="142.05371"
-       y="71.790039"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">M</text>
+       x="142"
+       y="72"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">M</text>
     <text
-       x="176.13086"
-       y="71.790039"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">N</text>
+       x="177"
+       y="72"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">N</text>
     <text
-       x="208.50391"
-       y="71.780273"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">O</text>
+       x="209"
+       y="72"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">O</text>
     <text
-       x="144.16309"
-       y="104.29004"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">P</text>
+       x="147"
+       y="104"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">P</text>
     <text
-       x="176.00391"
-       y="102.96191"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">Q</text>
+       x="177"
+       y="104"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">Q</text>
     <text
-       x="208.58203"
-       y="104.29004"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">R</text>
+       x="210"
+       y="104"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">R</text>
     <text
-       x="57.062901"
-       y="170.56708"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">S</text>
+       x="58"
+       y="170"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">S</text>
     <text
-       x="36.220795"
-       y="191.79004"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">T</text>
+       x="36"
+       y="192"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">T</text>
     <text
-       x="77.343483"
-       y="191.64844"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">U</text>
+       x="78"
+       y="192"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">U</text>
     <text
-       x="56.511143"
-       y="213.00323"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">V</text>
+       x="58"
+       y="213"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">V</text>
     <text
-       x="173.23477"
-       y="170.57684"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">W</text>
+       x="175"
+       y="171"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">W</text>
     <text
-       x="155.33701"
-       y="191.79004"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">X</text>
+       x="155"
+       y="192"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">X</text>
     <text
-       x="198.22238"
-       y="191.79004"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">Y</text>
+       x="198"
+       y="192"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">Y</text>
     <text
-       x="176.99942"
-       y="213.00323"
-       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Bitstream Vera Sans">Z</text>
+       x="179"
+       y="213"
+       style="font-size:20px;font-style:normal;font-weight:bold;fill:#000000;fill-opacity:1;font-family:Roboto, Helvetica, Arial, sans-serif">Z</text>
   </g>
 </svg>


### PR DESCRIPTION
This adds a font definition to the pigpen SVG so that it renders consistently on all platforms - on some platforms it was serif, some it was sans serif before.

While we're at it, tweak placement of the letters so that they line up better.

Before:
![image](https://user-images.githubusercontent.com/2019044/69404658-a75fb200-0cb2-11ea-8f3a-323f2a6b692e.png)

After:
![image](https://user-images.githubusercontent.com/2019044/69405173-dd516600-0cb3-11ea-9345-f40e7b2b506e.png)
