### PR TITLE
Switch over to HTML5 navigation

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>Single Page Apps for GitHub Pages</title>
+  <script type="text/javascript">
+    // Single Page Apps for GitHub Pages
+    // https://github.com/rafrex/spa-github-pages
+    // Copyright (c) 2016 Rafael Pedicini, licensed under the MIT License
+    // ----------------------------------------------------------------------
+    // This script takes the current url and converts the path and query
+    // string into just a query string, and then redirects the browser
+    // to the new url with only a query string and hash fragment,
+    // e.g. http://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+    // http://www.foo.tld/?p=/one/two&q=a=b~and~c=d#qwe
+    // Note: this 404.html file must be at least 512 bytes for it to work
+    // with Internet Explorer (it is currently > 512 bytes)
+
+    // If you're creating a Project Pages site and NOT using a custom domain,
+    // then set segmentCount to 1 (enterprise users may need to set it to > 1).
+    // This way the code will only replace the route part of the path, and not
+    // the real directory in which the app resides, for example:
+    // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+    // https://username.github.io/repo-name/?p=/one/two&q=a=b~and~c=d#qwe
+    // Otherwise, leave segmentCount as 0.
+    var segmentCount = 0;
+
+    var l = window.location;
+    l.replace(
+      l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+      l.pathname.split('/').slice(0, 1 + segmentCount).join('/') + '/?p=/' +
+      l.pathname.slice(1).split('/').slice(segmentCount).join('/').replace(/&/g, '~and~') +
+      (l.search ? '&q=' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+      l.hash
+    );
+
+  </script>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/public/404.html
+++ b/public/404.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Single Page Apps for GitHub Pages</title>
+  <title>PuzzTool</title>
   <script type="text/javascript">
     // Single Page Apps for GitHub Pages
     // https://github.com/rafrex/spa-github-pages

--- a/public/index.html
+++ b/public/index.html
@@ -1,21 +1,59 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover, user-scalable=no, shrink-to-fit=no" />
-    <meta name="theme-color" content="#000000" />
-    <meta name="keywords" content="puzzle, solver, puzztool, puzz, tool, cipher, braille, semaphore" />
-    <meta name="description" content="PuzzTool helps solve encodings and ciphers used in puzzle competitions such as Puzzle Hunt, Puzzled Pint, and others" />
-    <meta name="robots" content="index, follow" />
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <link rel="shortcut icon" href="%PUBLIC_URL%/icons-64.png" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/icons-192-fill.png" />
-    <title>PuzzTool</title>
-  </head>
-  <body>
-    <noscript>
-      You need to enable JavaScript to run this app.
-    </noscript>
-    <div id="root"></div>
-  </body>
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport"
+    content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover, user-scalable=no, shrink-to-fit=no" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="keywords" content="puzzle, solver, puzztool, puzz, tool, cipher, braille, semaphore" />
+  <meta name="description"
+    content="PuzzTool helps solve encodings and ciphers used in puzzle competitions such as Puzzle Hunt, Puzzled Pint, and others" />
+  <meta name="robots" content="index, follow" />
+  <base href="%PUBLIC_URL%/" />
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <link rel="shortcut icon" href="%PUBLIC_URL%/icons-64.png" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/icons-192-fill.png" />
+  <title>PuzzTool</title>
+
+  <!-- Start Single Page Apps for GitHub Pages -->
+  <script type="text/javascript">
+    // Single Page Apps for GitHub Pages
+    // https://github.com/rafrex/spa-github-pages
+    // Copyright (c) 2016 Rafael Pedicini, licensed under the MIT License
+    // ----------------------------------------------------------------------
+    // This script checks to see if a redirect is present in the query string
+    // and converts it back into the correct url and adds it to the
+    // browser's history using window.history.replaceState(...),
+    // which won't cause the browser to attempt to load the new url.
+    // When the single page app is loaded further down in this file,
+    // the correct url will be waiting in the browser's history for
+    // the single page app to route accordingly.
+    (function (l) {
+      if (l.search) {
+        var q = {};
+        l.search.slice(1).split('&').forEach(function (v) {
+          var a = v.split('=');
+          q[a[0]] = a.slice(1).join('=').replace(/~and~/g, '&');
+        });
+        if (q.p !== undefined) {
+          window.history.replaceState(null, null,
+            l.pathname.slice(0, -1) + (q.p || '') +
+            (q.q ? ('?' + q.q) : '') +
+            l.hash
+          );
+        }
+      }
+    }(window.location))
+  </script>
+  <!-- End Single Page Apps for GitHub Pages -->
+</head>
+
+<body>
+  <noscript>
+    You need to enable JavaScript to run this app.
+  </noscript>
+  <div id="root"></div>
+</body>
+
 </html>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
+  ReactDOM.render(
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>,
+    div);
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { HashRouter as Router, Route } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import Loadable from 'react-loadable';
 import AppNav from './Features/AppNav';
+import NotFound from './Features/Error/NotFound';
 import Loading from './Common/Loading';
 import './App.scss';
 
@@ -99,28 +100,29 @@ const Vigenere = Loadable({
 
 function App() {
   return (
-    <Router>
-      <div className="App">
-        <AppNav />
-        <div className="App-content">
+    <div className="App">
+      <AppNav />
+      <div className="App-content">
+        <Switch>
           <Route exact={true} path="/" component={Home} />
-          <Route path="/cipher/autokey" component={Autokey} />
-          <Route path="/cipher/caesar" component={Caesar} />
-          <Route path="/cipher/vigenere" component={Vigenere} />
-          <Route path="/encoding/autoconvert" component={AutoConvert} />
-          <Route path="/encoding/braille" component={Braille} />
-          <Route path="/encoding/morse" component={Morse} />
-          <Route path="/encoding/pigpen" component={Pigpen} />
-          <Route path="/encoding/semaphore" component={Semaphore} />
-          <Route path="/help/settings" component={Settings} />
-          <Route path="/reference/characterencodings" component={Character} />
-          <Route path="/reference/nato" component={Nato} />
-          <Route path="/reference/navalflags" component={NavalFlag} />
-          <Route path="/reference/resistors" component={Resistor} />
-          <Route path="/solvers/wordsearch" component={WordSearch} />
-        </div>
+          <Route exact={true} path="/cipher/autokey" component={Autokey} />
+          <Route exact={true} path="/cipher/caesar" component={Caesar} />
+          <Route exact={true} path="/cipher/vigenere" component={Vigenere} />
+          <Route exact={true} path="/encoding/autoconvert" component={AutoConvert} />
+          <Route exact={true} path="/encoding/braille" component={Braille} />
+          <Route exact={true} path="/encoding/morse" component={Morse} />
+          <Route exact={true} path="/encoding/pigpen" component={Pigpen} />
+          <Route exact={true} path="/encoding/semaphore" component={Semaphore} />
+          <Route exact={true} path="/help/settings" component={Settings} />
+          <Route exact={true} path="/reference/characterencodings" component={Character} />
+          <Route exact={true} path="/reference/nato" component={Nato} />
+          <Route exact={true} path="/reference/navalflags" component={NavalFlag} />
+          <Route exact={true} path="/reference/resistors" component={Resistor} />
+          <Route exact={true} path="/solvers/wordsearch" component={WordSearch} />
+          <Route component={NotFound} />
+        </Switch>
       </div>
-    </Router>
+    </div>
   );
 }
 

--- a/src/Features/Error/NotFound.scss
+++ b/src/Features/Error/NotFound.scss
@@ -1,0 +1,3 @@
+.NotFound {
+  padding: 0 1rem 1rem;
+}

--- a/src/Features/Error/NotFound.tsx
+++ b/src/Features/Error/NotFound.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import './NotFound.scss';
+
+function NotFound() {
+  return (
+    <div className="NotFound">
+      <h1>Not Found</h1>
+      <p>If this was reached in error, use the navigation options or go <Link to="/">home</Link>.</p>
+    </div>
+  );
+}
+
+export default NotFound;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,18 @@
+import { createBrowserHistory } from 'history';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 import './index.scss';
+import { Router } from 'react-router-dom';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const baseUrl = document.getElementsByTagName('base')[0].getAttribute('href') || '';
+const history = createBrowserHistory({ basename: baseUrl });
+
+ReactDOM.render(
+  <Router history={history}>
+    <App />
+  </Router>,
+  document.getElementById('root'));
 
 serviceWorker.register();


### PR DESCRIPTION
GitHub doesn't support HTML5 navigation very well, but with a workaround
it's possible to use it. If the user loads the index then navigation
works as normal, but if the user loads another path the 404 page kicks
in to redirect back to the index without losing the route.

Also add a default handler with 404 content.