### PR TITLE
Update the `start_url` to leave out `index.html`

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -22,7 +22,7 @@
       "purpose": "maskable"
     }
   ],
-  "start_url": "./index.html",
+  "start_url": "./",
   "display": "standalone",
   "theme_color": "#000000",
   "background_color": "#ffffff"


### PR DESCRIPTION
Having `index.html` in the path causes navigation to fail.