### PR TITLE
[References] Tweak the sizes slightly for mobile

### DIFF
--- a/src/Features/Encoding/NavalFlag/index.scss
+++ b/src/Features/Encoding/NavalFlag/index.scss
@@ -1,3 +1,3 @@
 .NavalFlag-flagImage {
-  width: 6.25rem;
+  width: 6rem;
 }

--- a/src/Features/Encoding/Semaphore/SemaphoreReference.tsx
+++ b/src/Features/Encoding/Semaphore/SemaphoreReference.tsx
@@ -10,7 +10,7 @@ function SemaphoreReference() {
       {characters.map((entry) => (
         <div>
           <SemaphorePicture
-            width={100}
+            width={96}
             character={new Character(entry.encoding, entry.category)}
           />
           <br />{entry.display}


### PR DESCRIPTION
The width is just a little too wide to get three across on the iPhone
Xs. Tweaking the widths slightly fixes it.

Now there are three across for both iPhone Xs and Pixel 3a.