### PR TITLE
[pigpen] Use ES module import instead of require

### DIFF
--- a/src/Features/Pigpen/index.tsx
+++ b/src/Features/Pigpen/index.tsx
@@ -1,4 +1,5 @@
 import PuzzToolPage from '../../Common/PuzzToolPage';
+import PigpenKey from '../../Images/pigpen_key.svg';
 import './index.scss';
 
 function Pigpen() {
@@ -7,7 +8,7 @@ function Pigpen() {
       <div className="Pigpen">
         <img
           className="Pigpen-img"
-          src={require('../../Images/pigpen_key.svg')}
+          src={PigpenKey}
           alt="Pigpen cipher reference chart"
         />
       </div>


### PR DESCRIPTION
At some point the `require` used here changed behavior. Use ES module
import instead.