### PR TITLE
Fix link behavior to prevent navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "react-helmet-async": "^1.1.2",
         "react-loadable": "^5.5.0",
         "react-redux": "^7.2.6",
+        "react-router-bootstrap": "^0.26.0",
         "react-router-dom": "^6.0.2",
         "react-scripts": "^4.0.3",
         "redux": "^4.1.1",
@@ -15761,6 +15762,18 @@
       },
       "peerDependencies": {
         "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-bootstrap": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/react-router-bootstrap/-/react-router-bootstrap-0.26.0.tgz",
+      "integrity": "sha512-auVpsCOYgI+3CrmtpVjme8ucz76iiMvJhv2BrnWof2HtimrF9NtAHtFzdZrsku5hwp166EPbz7IuSyHJA8kkdA==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1",
+        "react-router-dom": ">=6.0.0"
       }
     },
     "node_modules/react-router-dom": {
@@ -33460,6 +33473,14 @@
       "integrity": "sha512-55o96RiDZmC0uD17DPqVmzzfdNd2Dc+EjkYvMAmHl43du/GItaTdFr5WwjTryNWPXZ+OOVQxQhwAX25UwxpHtw==",
       "requires": {
         "history": "^5.1.0"
+      }
+    },
+    "react-router-bootstrap": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/react-router-bootstrap/-/react-router-bootstrap-0.26.0.tgz",
+      "integrity": "sha512-auVpsCOYgI+3CrmtpVjme8ucz76iiMvJhv2BrnWof2HtimrF9NtAHtFzdZrsku5hwp166EPbz7IuSyHJA8kkdA==",
+      "requires": {
+        "prop-types": "^15.7.2"
       }
     },
     "react-router-dom": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-helmet-async": "^1.1.2",
     "react-loadable": "^5.5.0",
     "react-redux": "^7.2.6",
+    "react-router-bootstrap": "^0.26.0",
     "react-router-dom": "^6.0.2",
     "react-scripts": "^4.0.3",
     "redux": "^4.1.1",

--- a/src/Features/AppNav/AppNavDropdownItem.tsx
+++ b/src/Features/AppNav/AppNavDropdownItem.tsx
@@ -1,6 +1,6 @@
 import { ReactChild } from "react";
 import NavDropdown from "react-bootstrap/NavDropdown";
-import { useHref, useMatch } from "react-router";
+import { LinkContainer } from "react-router-bootstrap";
 
 interface Props {
   children: ReactChild | ReactChild[];
@@ -9,16 +9,12 @@ interface Props {
 }
 
 function AppNavDropdownItem(props: Props) {
-  const routeMatch = useMatch(props.to);
-
   return (
-    <NavDropdown.Item
-      active={!!routeMatch}
-      eventKey={props.eventKey}
-      href={useHref(props.to)}
-    >
-      {props.children}
-    </NavDropdown.Item>
+    <LinkContainer to={props.to}>
+      <NavDropdown.Item eventKey={props.eventKey}>
+        {props.children}
+      </NavDropdown.Item>
+    </LinkContainer>
   );
 }
 

--- a/src/Features/AppNav/index.tsx
+++ b/src/Features/AppNav/index.tsx
@@ -1,6 +1,6 @@
 import Nav from "react-bootstrap/Nav";
 import Navbar from "react-bootstrap/Navbar";
-import { useHref } from "react-router";
+import { LinkContainer } from "react-router-bootstrap";
 import { getCategories } from "../../Data/RouteData";
 import PuzztoolBannerWhite from "../../Images/puzztool_banner_white.svg";
 import AppNavCategory from "./AppNavCategory";
@@ -21,13 +21,15 @@ function AppNav() {
       sticky="top"
       variant="dark"
     >
-      <Navbar.Brand href={useHref("/")}>
-        <img
-          className={styles.logo}
-          src={PuzztoolBannerWhite}
-          alt="PuzzTool logo"
-        />
-      </Navbar.Brand>
+      <LinkContainer to="/">
+        <Navbar.Brand>
+          <img
+            className={styles.logo}
+            src={PuzztoolBannerWhite}
+            alt="PuzzTool logo"
+          />
+        </Navbar.Brand>
+      </LinkContainer>
       <Navbar.Toggle />
       <Navbar.Collapse>
         <Nav>


### PR DESCRIPTION
In a previous change the `LinkContainer` was removed. This caused
certain navigations to start hitting the server/service worker. Add it
back to prevent that, it has been updated to be compatible now.
